### PR TITLE
Better expression for Kalman Gain

### DIFF
--- a/vi_rnn/vae.py
+++ b/vi_rnn/vae.py
@@ -105,15 +105,18 @@ class VAE(nn.Module):
 
         # project and clamp the variances
         eff_var_prior = self.rnn.full_cov_embed(self.rnn.R_z)
-        eff_var_x_diag = torch.diag(
-            torch.clip(self.rnn.var_embed_x(self.rnn.R_x), 1e-8)
-        )
-        eff_std_x = torch.clip(self.rnn.std_embed_x(self.rnn.R_x), 1e-4)
         eff_var_prior_t0 = self.rnn.full_cov_embed(self.rnn.R_z_t0)
         eff_var_prior_chol = self.rnn.chol_cov_embed(self.rnn.R_z)
         eff_var_prior_t0_chol = self.rnn.chol_cov_embed(self.rnn.R_z_t0)
+  
+        eff_var_x = torch.clip(self.rnn.var_embed_x(self.rnn.R_x), 1e-8)
+        eff_var_x_inv=  1.0 / torch.clip(self.rnn.var_embed_x(self.rnn.R_x), 1e-8)
+        eff_std_x = torch.clip(self.rnn.std_embed_x(self.rnn.R_x), 1e-4)
+  
+     
+     
         batch_size, dim_x, time_steps = x.shape
-        # print(eff_var_prior,eff_var_x_diag,eff_std_x,eff_var_prior_t0,eff_var_prior_chol,eff_var_prior_t0_chol)
+        dim_z = self.dim_z
 
         # Get the initial prior mean
         if sim_v:
@@ -144,22 +147,30 @@ class VAE(nn.Module):
         Obs_bias = self.rnn.observation.Bias.squeeze(-1)
 
         # Calculate the Kalman gain and interpolation alpha
-        Kalman_gain = (
-            eff_var_prior_t0
-            @ B
-            @ torch.linalg.inv(eff_var_x_diag + B.T @ eff_var_prior_t0 @ B)
-        )
+        if dim_x<dim_z:
+            Kalman_gain = (
+                eff_var_prior_t0
+                @ B
+                @ torch.linalg.inv(torch.diag(eff_var_x) + B.T @ eff_var_prior_t0 @ B)
+            )
+        else: # this is generally faster for low-rank models
+            Kalman_gain = (
+                torch.linalg.inv(torch.cholesky_inverse(eff_var_prior_t0_chol)+(B *torch.unsqueeze(eff_var_x_inv,0)) @ B.T)
+                @(B *torch.unsqueeze(eff_var_x_inv,0))
+            )
+
         alpha = Kalman_gain @ B.T
         one_min_alpha = torch.eye(self.dim_z, device=alpha.device) - alpha
 
         # Posterior Joseph stabilised Covariance
-        var_Q = (
-            one_min_alpha @ eff_var_prior_t0 @ one_min_alpha.T
-            + Kalman_gain @ eff_var_x_diag @ Kalman_gain.T
+        var_Q =(
+             one_min_alpha @ eff_var_prior_t0 @ one_min_alpha.T
+            + (Kalman_gain * torch.unsqueeze(eff_var_x,0)) @ Kalman_gain.T
         )
         var_Q = (
             torch.eye(self.dim_z, device=alpha.device) * 1e-8 + (var_Q + var_Q.T) / 2
         )
+        
         var_Q_cholesky = torch.linalg.cholesky(var_Q)
         # Posterior Mean
 
@@ -205,6 +216,36 @@ class VAE(nn.Module):
         time_steps = x.shape[2]
         u = u.unsqueeze(-1)  # account for k
 
+
+        # precalculate Kalman Gain / Interpolation
+        if dim_x<dim_z:
+            Kalman_gain = (
+                eff_var_prior
+                @ B
+                @ torch.linalg.inv(torch.diag(eff_var_x) + B.T @ eff_var_prior @ B)
+            )
+        else:
+            Kalman_gain = (
+                torch.linalg.inv(torch.cholesky_inverse(eff_var_prior_chol)+(B *torch.unsqueeze(eff_var_x_inv,0)) @ B.T)
+                @(B *torch.unsqueeze(eff_var_x_inv,0))
+            )
+
+        alpha = Kalman_gain @ B.T
+        one_min_alpha = torch.eye(self.dim_z, device=alpha.device) - alpha
+
+        # Posterior Joseph stabilised Covariance
+        var_Q =(
+             one_min_alpha @ eff_var_prior @ one_min_alpha.T
+            + (Kalman_gain * torch.unsqueeze(eff_var_x,0)) @ Kalman_gain.T
+        )
+        
+        var_Q = (
+            torch.eye(self.dim_z, device=alpha.device) * 1e-8
+            + (var_Q + var_Q.T) / 2
+        )
+        var_Q_cholesky = torch.linalg.cholesky(var_Q)
+
+
         # Start the loop through the time steps
         for t in range(1, time_steps):
             # Resample if necessary
@@ -229,14 +270,8 @@ class VAE(nn.Module):
             else:
                 v = u[:, :, t].unsqueeze(2)
             # Calculate the Kalman gain and interpolation alpha
-            Kalman_gain = (
-                eff_var_prior
-                @ B
-                @ torch.linalg.inv(eff_var_x_diag + B.T @ eff_var_prior @ B)
-            )
-            alpha = Kalman_gain @ B.T
-            one_min_alpha = torch.eye(self.dim_z, device=alpha.device) - alpha
-
+         
+           
             # Calculate the posterior mean and Joseph stabilised covariance
             if self.rnn.params['readout_from']=="currents":
                 v_to_X = torch.einsum(
@@ -246,19 +281,10 @@ class VAE(nn.Module):
                 v_to_X =0
             
             x_t = x[:, :, t] - Obs_bias - v_to_X
-
+         
             mean_Q = torch.einsum(
                 "zs,BsK->BzK", one_min_alpha, prior_mean
             ) + torch.einsum("zx,BxK->BzK", Kalman_gain, x_t)
-            var_Q = (
-                one_min_alpha @ eff_var_prior @ one_min_alpha.T
-                + Kalman_gain @ eff_var_x_diag @ Kalman_gain.T
-            )
-            var_Q = (
-                torch.eye(self.dim_z, device=alpha.device) * 1e-8
-                + (var_Q + var_Q.T) / 2
-            )
-            var_Q_cholesky = torch.linalg.cholesky(var_Q)
 
             # Sample from the posterior and calculate likelihood
             Q_dist = torch.distributions.MultivariateNormal(


### PR DESCRIPTION
For linear Gaussian observations $p(y_t \mid z_t)=\mathcal{N}(Wz_t,\Sigma_y)$  and transitions $p(z_{t}\mid z_{t-1})=\mathcal{N}(F(z_{t-1}, \Sigma_z)$ we use the 'optimal' closed-form proposal $p(z_t|y_t,z_{t-1})$.

The expression for this can be written such that it includes the Kalman Gain, for which two equivalent expressions can be obtained

$$K=(\Sigma_z^{-1}+W^\mathsf{T}\Sigma_y^{-1}W)^{-1}W^\mathsf{T}\Sigma_y^{-1}$$

and:

$${K=\Sigma_zW^\mathsf{T}(W\Sigma_zW^\mathsf{T}+\Sigma_y)^{-1}}$$

Given that we assume $\Sigma_y$ is diagonal, the first expression only requires inverting matrices of size dimension of the latents (rank of the RNN). We also have access to the cholesky decomposition of $\Sigma_z$, making its inverse more efficient. The second equation requires inverting a matrix of size observation dimension (this matrix can also be badly conditioned if $\Sigma_y$ is small). 

So the first equation is preferred if the observation dim is higher than the latent dim (generally the case in this project).

When using the first expression, one also immediately computes the proposal covariance, as it is equal to $(\Sigma_z^{-1}+W^\mathsf{T}\Sigma_y^{-1}W)^{-1}$.